### PR TITLE
Extend `edoc_opts` to force `dir` attribute without wiping out existing options

### DIFF
--- a/src/medoc.erl
+++ b/src/medoc.erl
@@ -30,7 +30,8 @@ init(State) ->
 		]),
 	%% Put all the docs into single dir
 	% {edoc_opts, [{dir, "doc"}]}.
-	State2 = rebar_state:set(State, edoc_opts, [{dir, ?DOC_DIR}]),
+	EDocOpts = rebar_state:get(State, edoc_opts),
+	State2 = rebar_state:set(State, edoc_opts, [{dir, ?DOC_DIR} | proplists:delete(dir, EDocOpts)]),
 	{ok, rebar_state:add_provider(State2, Provider)}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.


### PR DESCRIPTION
Previously when replacing `edoc_opts` all existing values were
tossed out and thus prevented setting unrelated options such as
the export of hidden and private functions or allowing TODO lists.

After this change we take the existing `edoc_opts` value and force
the `dir` property without removing the other existing keys. This
allows for those existing properties to continue to be set.